### PR TITLE
Revised package to not pull in breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "debug": "~0.7.4",
     "point-free": ">=0.0.1",
     "pg": ">=3.4.1",
-    "sql-bricks": ">=0.10.0"
+    "sql-bricks": "0.x"
   }
 }


### PR DESCRIPTION
@Suor: This looks like a cool library, thanks for building on top of sql-bricks!

I plan on making some breaking changes to the sql-bricks API in version 1.0 -- in particular, pulling the postgres-specific clauses (limit, offset, returning, and perhaps one or two more) into a separate extension file, so in order to get the core (SQL-92) functionality plus the postgres functionality, you would do require('sql-bricks/postgres') instead of require('sql-bricks').
