### PR TITLE
Fixing PG.connect is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "~2.2.0",
+    "debug": "~2.6.8",
     "point-free": "0.7.0",
-    "pg": "^6.0",
+    "pg": "^6.4.0",
     "sql-bricks-postgres": ">=0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-bricks",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Higher level PostgreSQL client",
   "keywords": [
     "postgres",


### PR DESCRIPTION
Transforming the connection string to connection object was described here: https://github.com/brianc/node-pg-pool#note

Fix #14
