### PR TITLE
Update pg dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function Conf(config, _pg) {
     if (typeof config === 'string') config = {connectionString: config};
     this._config = config;
     this._pg = _pg || pg;
-    this._pool = this._pg.Pool(config);
+    this._pool = new this._pg.Pool(config);
 }
 
 Conf.prototype = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-bricks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Higher level PostgreSQL client",
   "keywords": [
     "postgres",
@@ -33,8 +33,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "~2.2.0",
-    "pg": "^7.1",
+    "debug": "~4.2.0",
+    "pg": "^8.5",
     "point-free": "0.7.0",
     "sql-bricks-postgres": ">=0.3.0"
   },


### PR DESCRIPTION
In Node v14 the old pg dependency stopped working, never resolving on any promises.
This PR updates pg to minimal v8.5, which doesn't have this problem. Updating to pg8 requires the client pool to be created as a constructor.